### PR TITLE
Sharpen Forge's identity as an initiative design tool

### DIFF
--- a/FORGE.md
+++ b/FORGE.md
@@ -1,10 +1,10 @@
 # Forge
 
-> A framework for agentic AI software engineering workspaces
+> A framework for designing software engineering initiatives with AI agents
 
-Forge is a framework for structuring collaborative workspaces where software engineers and AI agents work together
-on design and documentation. It provides conventions for organizing context, writing artifacts, and moving ideas from
-rough exploration to implementation-ready decisions.
+Forge is a framework for structuring collaborative workspaces where software engineers and AI agents design
+initiatives together. It provides conventions for organizing context, writing artifacts, and moving ideas from rough
+exploration to implementation-ready decisions.
 
 ---
 
@@ -46,7 +46,7 @@ Forge addresses this by:
 - **Connecting to reality** by linking workspaces to actual codebases and external systems. AI agents can read real
   implementations, not just descriptions of them.
 - **Defining workflows** that move systematically from exploration to actionable work.
-- **Living alongside code** as a git-tracked workspace that evolves with the systems it documents.
+- **Living alongside code** as a git-tracked workspace that captures design thinking before implementation begins.
 
 > **Note:** This documentation uses `AGENTS.md` as the generic name for context files. Rename to your AI tool's
 > convention: `CLAUDE.md` for Claude Code, `.cursorrules` for Cursor, `COPILOT.md` for GitHub Copilot, etc.
@@ -65,7 +65,7 @@ design work. The conventions are tool-agnostic; adapt the context file naming to
 
 Forge is designed for software engineering teams who:
 
-- Use AI agents for design and documentation work.
+- Use AI agents for design and decision-making work.
 - Want to preserve and build on design discussions rather than lose them.
 - Need AI collaborators that understand their specific systems and conventions.
 - Value written artifacts over verbal discussions for technical decisions.
@@ -102,7 +102,7 @@ inside them:
 └── shared-libraries/
 ```
 
-This separation keeps concerns clean: Forge handles design and documentation, repositories handle code. The **Related
+This separation keeps concerns clean: Forge handles initiative design, repositories handle code. The **Related
 Repositories** pattern in product `AGENTS.md` files (with paths in the companion `REPOS.md`) links the two, allowing
 AI agents to read actual implementations when discussing design.
 This also hooks into the reality that the relationships between repositories are often more complex than being
@@ -263,12 +263,29 @@ paths differ per developer, so they live in a separate `REPOS.md` inside each pr
   the product `AGENTS.md`'s `## Related Repositories` table.
 - **Required for repo access.** AI agents use `REPOS.md` to resolve repository names to actual paths on
   disk. Without it, they cannot read source code for that product's repositories.
+- **Primary bridge to truth.** `REPOS.md` is not just a path listing — it connects Forge's design
+  artifacts to the authoritative source code. When starting an initiative, follow these paths to
+  understand the current state of the system rather than relying solely on curated summaries.
 
 **Template:** See [Templates/REPOS.EXAMPLE.md](./Templates/REPOS.EXAMPLE.md). Copy to
 `Products/<Product>/REPOS.md` and fill in your local paths.
 
 Run `/forge-validate` to check for drift between `REPOS.md` and the product `AGENTS.md` — it will flag
 repositories present in one but missing from the other.
+
+### Reference Materials (`References/`)
+
+`References/` directories exist at both product and initiative levels. Their role depends on how well-documented the
+connected repositories are:
+
+- **If repositories have their own documentation** (architecture docs, READMEs, inline docs): Use `References/` only
+  for genuinely external material — third-party API docs, regulatory requirements, vendor specifications, or other
+  material that doesn't live in any repository.
+- **If repositories lack documentation:** `References/` fills the gap as primary context. Store architecture overviews,
+  API contracts, and system descriptions here until the repositories themselves have proper documentation.
+
+In either case, prefer reading actual repository content (via `REPOS.md` paths) over relying on `References/` copies,
+which can drift from reality. See [Trust Hierarchy](#trust-hierarchy).
 
 ### Team Roster (`TEAM.md`)
 
@@ -506,6 +523,26 @@ Each stage has a corresponding command. See [Commands & Skills](#commands--skill
 **Practical notes:** Stages are a guide, not a mandate. `Design` often reveals gaps that send us back to `Discover`.
 Small changes might skip stages entirely. Some initiatives die early – keep them around to preserve the learning.
 
+### After Decompose: Artifacts Become Historical
+
+Once an initiative completes (tickets are created and implementation begins), its artifacts become **point-in-time
+historical records**, not current truth. The code that gets built is the authoritative source — not the proposals and
+decisions that led to it.
+
+This matters because:
+
+- **Implementation diverges from design.** Real-world constraints, discoveries during coding, and evolving requirements
+  mean the final system rarely matches the original proposal exactly.
+- **Stale artifacts mislead AI agents.** An AI reading an old proposal may treat it as current intent rather than
+  historical context, leading to suggestions based on outdated assumptions.
+- **The code is the source of truth.** After implementation, read the actual codebase (via Related Repositories) to
+  understand what was built. Read the initiative artifacts to understand *why* it was built that way — but verify
+  against the code before acting on any specifics.
+
+Completed initiative artifacts remain valuable as historical context — they capture the reasoning, trade-offs, and
+alternatives considered. But they are snapshots of a moment in time, not living documents that track the current state
+of the system. See [Keep as History, Not as Truth](#keep-as-history-not-as-truth).
+
 ---
 
 ## Commands & Skills
@@ -701,6 +738,10 @@ Stale context is worse than no context; it misleads. Update `AGENTS.md` files wh
 - `Initiatives` complete or change in direction.
 - Conventions evolve.
 
+> **Note:** This guidance applies to `AGENTS.md` context files, which describe current state. Initiative artifacts
+> (`Exploration.md`, `Proposal.md`, `Decision.md`) are point-in-time records and should NOT be retroactively updated —
+> see [After Decompose: Artifacts Become Historical](#after-decompose-artifacts-become-historical).
+
 #### Staleness Detection
 
 Use version control or filesystem to check when files were last updated:
@@ -779,6 +820,20 @@ data flows where, and where integration points exist.
 
 Isolated documents lose context over time.
 
+### Trust Hierarchy
+
+When information conflicts across sources, follow this precedence:
+
+1. **Code** (via Related Repositories) — the ultimate source of truth for what exists today.
+2. **Repository documentation** — README files, inline docs, and architecture docs within code repos.
+3. **Forge context files** (`AGENTS.md`) — curated summaries that may lag behind the code.
+4. **`References/`** — external materials that may be outdated copies or third-party docs.
+5. **Completed initiative artifacts** — historical records that reflect intent at a point in time, not necessarily
+   current reality.
+
+When in doubt, read the code. `AGENTS.md` summaries and `References/` materials are valuable for orientation and
+understanding intent, but the codebase is authoritative for current behavior.
+
 ### Push When Ready
 
 Push finalized artifacts to external systems for team visibility using `/forge-push`. Keep Forge as the authoring
@@ -786,9 +841,14 @@ environment during design time and push when the artifact is stable enough for e
 `Draft` artifacts unless the team expects to collaborate externally during early stages. Use `/forge-pull` to
 incorporate changes made by external collaborators before resuming local edits.
 
-### Keep, Don't Delete
+### Keep as History, Not as Truth
 
-When work completes, leave initiatives where they are rather than deleting them. Future-us might need that context.
+When an initiative completes, leave its artifacts in place — they preserve valuable reasoning about *why* decisions were
+made. But treat them as historical records, not current documentation. The code is the source of truth for *what* was
+built; initiative artifacts explain the thinking that led there.
+
+When reading completed initiatives, verify any specifics against the actual codebase before acting on them.
+Implementations frequently diverge from original proposals as real-world constraints emerge.
 
 ### Know When to Stop Documenting
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p align="center">
   <img src="logo.png" alt="Forge logo" width="300">
   <br><br>
-  <strong>A framework for agentic AI software engineering workspaces</strong>
+  <strong>A framework for designing software engineering initiatives with AI agents</strong>
   <br><br>
   <a href="./FORGE.md">Documentation</a> ·
   <a href="./Templates/AGENTS.EXAMPLE.md">Template</a> ·
@@ -30,7 +30,7 @@ detailed guidance.
 
 - **Start simple:** Add structure only when it helps, not preemptively.
 - **Keep context current:** Stale `AGENTS.md` files mislead more than they help.
-- **Keep, don't delete:** Future-us might need that context.
+- **Keep as history:** Completed initiatives are historical records, not current truth.
 - **Link liberally:** Connect artifacts to each other and to code.
 - **Refine incrementally:** Messy exploration first, formal documents later.
 - **Know when to skip:** Not every change needs a proposal.
@@ -121,7 +121,8 @@ Not all tools support custom commands; check your tool's documentation.
 ```
 
 Then fill in the generated `AGENTS.md` with product context, link related repositories, and seed `References/` with
-existing documentation. Copy `Templates/REPOS.EXAMPLE.md` to the product directory as `REPOS.md` and fill in the
+external documentation (third-party APIs, regulatory docs). If your repositories lack their own docs, `References/` can
+also hold architecture overviews and system descriptions as interim context. Copy `Templates/REPOS.EXAMPLE.md` to the product directory as `REPOS.md` and fill in the
 local paths where you have each repository cloned (this file is gitignored — each team member has their own).
 
 **4. Start an initiative**

--- a/Templates/AGENTS.EXAMPLE.md
+++ b/Templates/AGENTS.EXAMPLE.md
@@ -1,6 +1,6 @@
 # Forge
 
-This is a collaborative workspace for brainstorming, designing, and documenting projects built on the **Forge**
+This is a collaborative workspace for exploring, designing, and deciding on initiatives built on the **Forge**
 framework.
 See [FORGE.md](./FORGE.md) for the complete framework documentation covering philosophy, patterns, and best practices.
 
@@ -10,7 +10,7 @@ You assist with:
 - **Technical Proposals:** Drafting technical proposals with clear problem statements, solutions, and alternatives.
 - **Ticket Creation:** Writing clear, actionable tickets with acceptance criteria.
 - **Design Documents:** Structuring architecture decisions and system designs.
-- **Technical Writing:** Documentation, architecture decisions, and other technical artifacts.
+- **Technical Writing:** Architecture decisions, proposals, and other design artifacts.
 
 ## Working Style
 

--- a/Templates/Initiative-AGENTS.EXAMPLE.md
+++ b/Templates/Initiative-AGENTS.EXAMPLE.md
@@ -57,3 +57,6 @@ this section provides human-readable context about *why* each dependency exists.
 - **Notes/:** Raw meeting notes and transcripts. Unfiltered, may be incomplete or contradictory.
 - **`Exploration.md`:** Refined synthesis. Use this as the source of truth for current understanding.
 - When Notes and Exploration conflict, trust Exploration or ask for clarification.
+- **Completed initiatives:** If this initiative has completed, all artifacts are point-in-time historical
+  records. The implemented code is the source of truth for current behavior. Read these artifacts for
+  context on *why* decisions were made, but verify any specifics against the codebase.

--- a/Templates/Product-AGENTS.EXAMPLE.md
+++ b/Templates/Product-AGENTS.EXAMPLE.md
@@ -69,6 +69,9 @@ Link to each initiative's context file so AI tools discover the full hierarchy.
 Stage can be set manually or inferred by /forge-status from artifacts present.
 Lead is optional — set it to the name or @handle of the person driving the initiative.
 Move completed initiatives to a "Completed Initiatives" section or remove them.
+Completed initiative artifacts are point-in-time historical records, not current truth.
+The code is authoritative — read initiative artifacts for the reasoning behind decisions,
+but verify specifics against the actual codebase.
 -->
 
 | Initiative                                                       | Stage    | Lead |
@@ -77,4 +80,9 @@ Move completed initiatives to a "Completed Initiatives" section or remove them.
 
 ## References
 
-<!-- Product-level documentation, wikis, runbooks -->
+<!--
+Product-level reference materials. If your repositories have their own documentation,
+limit this to genuinely external material (third-party APIs, regulatory docs, vendor specs).
+If repositories lack docs, this can hold architecture overviews and system descriptions.
+Prefer reading actual code via REPOS.md over relying on References/ copies.
+-->


### PR DESCRIPTION
## Summary

- **Reframes Forge's positioning** from "design and documentation" to purely initiative design. Forge is a workbench for the 4 D's lifecycle, not a documentation system.
- **Adds guidance on artifact ephemerality.** New "After Decompose: Artifacts Become Historical" section makes explicit that completed initiative artifacts are point-in-time snapshots, not living truth. Replaces "Keep, Don't Delete" with "Keep as History, Not as Truth."
- **Introduces a Trust Hierarchy** (code > repo docs > AGENTS.md > References/ > completed artifacts) so agents know what to trust when sources conflict.
- **Clarifies the role of References/**: external-only material if repos have their own docs, interim context if they don't.
- **Elevates REPOS.md** from "path listing" to "primary bridge to authoritative source code."

## Motivation

Accumulated initiative artifacts increasingly mislead AI agents who treat old proposals as current truth. Meanwhile, the framework's language implied it could serve as a documentation system, which it isn't designed for. These changes sharpen what Forge is (initiative design) and what it isn't (living documentation).

## Files changed

| File | What changed |
|---|---|
| `FORGE.md` | Positioning (4 spots), new lifecycle section, trust hierarchy, reference materials guidance, revised best practice |
| `README.md` | Tagline, golden rule, References/ guidance |
| `Templates/AGENTS.EXAMPLE.md` | Removed "documenting" and "Documentation" from purpose list |
| `Templates/Product-AGENTS.EXAMPLE.md` | Completed initiatives comment, References/ comment |
| `Templates/Initiative-AGENTS.EXAMPLE.md` | Completed initiative lifecycle note |

## Test plan

- [ ] Read through updated FORGE.md end-to-end for consistency
- [ ] Verify no remaining language positions Forge as a documentation tool
- [ ] Check all internal cross-reference anchors resolve correctly
- [ ] Confirm trust hierarchy doesn't contradict existing "Keep Context Files Current" or "Link Liberally" guidance